### PR TITLE
[FIX] mrp_subcontracting: fallback supplier selection for subcontracted BOM cost computation

### DIFF
--- a/addons/mrp_subcontracting/report/mrp_report_bom_structure.py
+++ b/addons/mrp_subcontracting/report/mrp_report_bom_structure.py
@@ -28,6 +28,10 @@ class ReportBomStructure(models.AbstractModel):
                 seller = bom.product_tmpl_id.seller_ids.filtered(lambda s: s.partner_id in bom.subcontractor_ids)[:1]
             else:
                 seller = res['product']._select_seller(quantity=res['quantity'], uom_id=bom.product_uom_id, params={'subcontractor_ids': bom.subcontractor_ids})
+                if not seller:
+                    # If no vendor found for the right quantity, still display
+                    # a vendor to ensure the subcontracting price is shown
+                    seller = res['product']._select_seller(quantity=None, uom_id=bom.product_uom_id, params={'subcontractor_ids': bom.subcontractor_ids})
             if seller:
                 res['subcontracting'] = self._get_subcontracting_line(bom, seller, level + 1, res['quantity'])
                 if not self.env.context.get('minimized', False):

--- a/addons/mrp_subcontracting_account/models/product_product.py
+++ b/addons/mrp_subcontracting_account/models/product_product.py
@@ -12,6 +12,10 @@ class ProductProduct(models.Model):
         price = super()._compute_bom_price(bom, boms_to_recompute, byproduct_bom)
         if bom and bom.type == 'subcontract':
             seller = self._select_seller(quantity=bom.product_qty, uom_id=bom.product_uom_id, params={'subcontractor_ids': bom.subcontractor_ids})
+            if not seller:
+                # Ensure the subcontracting price is always displayed even if no
+                # vendor matches the quantity
+                seller = self._select_seller(quantity=None, uom_id=bom.product_uom_id, params={'subcontractor_ids': bom.subcontractor_ids})
             if seller:
                 seller_price = seller.currency_id._convert(seller.price, self.env.company.currency_id, (bom.company_id or self.env.company), fields.Date.today())
                 price += seller.product_uom._compute_price(seller_price, self.uom_id)


### PR DESCRIPTION
This PR improves the consistency of subcontracted BOM cost computation and visualization in two key areas:

Structure View (report_mrp_bom_structure):
When displaying the cost breakdown of a subcontracted BOM, if no supplierinfo matches the exact quantity being simulated, the subcontracting cost would previously disappear entirely. This change introduces a fallback using _select_seller(quantity=None) to ensure a supplier is always selected when possible, maintaining a consistent and complete cost structure.

Standard Price Computation (_compute_bom_price in mrp_subcontracting_account):
Similarly, during the computation of standard_price (e.g., via button_bom_cost), if no matching supplierinfo exists for the BOM quantity, the subcontracting cost was excluded. This patch ensures a fallback supplier is also selected in this context, preventing underestimation of the product's real cost.

The fallback logic is applied only when no valid supplier is found for the desired quantity, preserving the intended prioritization of precise min_qty matches when available.

This change ensures alignment between cost visualization and standard cost computation for subcontracted products, and avoids silent cost omissions when using tiered supplier pricing.

---
I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)